### PR TITLE
Fixed issue with incorrect handler path being detected

### DIFF
--- a/src/lib/functions.js
+++ b/src/lib/functions.js
@@ -4,7 +4,7 @@ const list = require('./list');
 
 const handlerProp = R.prop('handler');
 
-const handlerPath = handler => R.replace(/\.[^.]+$/g, '.js', handler);
+const handlerPath = handler => R.replace(/\.[^.]+$/, '.js', handler);
 const handlerFile = R.compose(path.basename, handlerPath);
 const fnPath = R.compose(handlerPath, handlerProp);
 const fnFilename = R.compose(handlerFile, handlerProp);

--- a/src/lib/functions.js
+++ b/src/lib/functions.js
@@ -4,9 +4,7 @@ const list = require('./list');
 
 const handlerProp = R.prop('handler');
 
-const handlerExport = R.compose(R.last, R.split('.'));
-
-const handlerPath = handler => R.replace(handlerExport(handler), 'js', handler);
+const handlerPath = handler => R.replace(/\.[^.]+$/g, '.js', handler);
 const handlerFile = R.compose(path.basename, handlerPath);
 const fnPath = R.compose(handlerPath, handlerProp);
 const fnFilename = R.compose(handlerFile, handlerProp);

--- a/src/lib/functions.js
+++ b/src/lib/functions.js
@@ -4,7 +4,7 @@ const list = require('./list');
 
 const handlerProp = R.prop('handler');
 
-const handlerPath = handler => R.replace(/\.[^.]+$/, '.js', handler);
+const handlerPath = R.replace(/\.[^.]+$/, '.js');
 const handlerFile = R.compose(path.basename, handlerPath);
 const fnPath = R.compose(handlerPath, handlerProp);
 const fnFilename = R.compose(handlerFile, handlerProp);


### PR DESCRIPTION
Had an issue where a function with a handler defined as `handler.handler` was looking for a file named `js.handler`.  This should fix the handler file path replace.