### PR TITLE
Improve packaging of individual functions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,16 +54,6 @@ class ServerlessPluginWebpack {
       this.serverless.service.functions
     );
 
-    // This makes sure every file is excluded and only the fn (webpacked) file is in there
-    // except for node_modules, because those can be copied over
-    // TODO: finetune code and make other includes possible
-    Object.keys(this.serverless.service.functions).map((k) => {
-      this.serverless.service.functions[k].package = Object.assign({}, this.serverless.service.functions[k].package, {
-        individually: true,
-        exclude: ['**', '!node_modules/**'],
-      });
-    });
-
     // Run webpack
     return wpack.run(
       wpack.createConfigs(

--- a/src/index.js
+++ b/src/index.js
@@ -54,6 +54,16 @@ class ServerlessPluginWebpack {
       this.serverless.service.functions
     );
 
+    // This makes sure every file is excluded and only the fn (webpacked) file is in there
+    // except for node_modules, because those can be copied over
+    // TODO: finetune code and make other includes possible
+    Object.keys(this.serverless.service.functions).map((k) => {
+      this.serverless.service.functions[k].package = Object.assign({}, this.serverless.service.functions[k].package, {
+        individually: true,
+        exclude: ['**', '!node_modules/**'],
+      });
+    });
+
     // Run webpack
     return wpack.run(
       wpack.createConfigs(

--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,8 @@ class ServerlessPluginWebpack {
         this.originalServicePath,
         webpackDefaultOutput,
         webpackFolder
-      )
+      ),
+      this.serverless
     );
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ class ServerlessPluginWebpack {
     // Package individually and exclude everything at the service level
     this.serverless.service.package = {
       individually: true,
-      exclude: ['*'],
+      exclude: ['**'],
     };
 
     // Include bundle and update handler at function level

--- a/src/lib/functions.js
+++ b/src/lib/functions.js
@@ -12,16 +12,17 @@ const fnPath = R.compose(handlerPath, handlerProp);
 const fnFilename = R.compose(handlerFile, handlerProp);
 
 const setPackage = fn =>
-  R.assoc(
-    'package',
-    R.objOf(
-      'include',
-      R.compose(list, fnPath)(fn)
-    ),
+  R.merge(
+    {
+      package: {
+        include: R.compose(list, fnPath)(fn), // Only include the webpacked function
+        exclude: ['**', '!node_modules/**'], // This excludes all files except for copied node_modules/** to the artifact
+      },
+    },
     fn
   );
 
-const setPackageAndHandler = R.map(R.compose(setPackage));
+const setPackageAndHandler = R.map(setPackage);
 
 const setArtifacts = (serverlessPath, fns) => R.map(
   R.over(

--- a/src/lib/functions.js
+++ b/src/lib/functions.js
@@ -16,7 +16,7 @@ const setPackage = fn =>
     {
       package: {
         include: R.compose(list, fnPath)(fn), // Only include the webpacked function
-        exclude: ['**', '!node_modules/**'], // This excludes all files except for copied node_modules/** to the artifact
+        exclude: ['!node_modules/**'], // This reincludes (copied) node_modules/** to the artifact
       },
     },
     fn

--- a/src/lib/functions.js
+++ b/src/lib/functions.js
@@ -16,14 +16,12 @@ const setPackage = fn =>
     'package',
     R.objOf(
       'include',
-      R.compose(list, fnFilename)(fn)
+      R.compose(list, fnPath)(fn)
     ),
     fn
   );
 
-const setHandler = R.over(R.lensProp('handler'), path.basename);
-
-const setPackageAndHandler = R.map(R.compose(setHandler, setPackage));
+const setPackageAndHandler = R.map(R.compose(setPackage));
 
 const setArtifacts = (serverlessPath, fns) => R.map(
   R.over(

--- a/src/lib/wpack.js
+++ b/src/lib/wpack.js
@@ -70,7 +70,6 @@ const run = (configs, sls) =>
             hash: false,
             chunks: false,
             version: false,
-            cache: false,
           }));
 
           if (stats.hasErrors()) rej('Webpack compilation error, see stats above');

--- a/src/lib/wpack.js
+++ b/src/lib/wpack.js
@@ -13,7 +13,7 @@ const setEntry = (fn, servicePath) =>
   R.assoc(
     'entry',
     R.objOf(
-      functions.fnFilename(fn),
+      functions.fnPath(fn),
       path.join(servicePath, functions.fnPath(fn))
     )
   );
@@ -25,7 +25,7 @@ const setEntry = (fn, servicePath) =>
  * @returns {object} Webpack configuration
  */
 const setOutput = (defaultOutput, outputPath) =>
-  R.assoc(
+   R.assoc(
     'output',
     R.merge(
       defaultOutput,


### PR DESCRIPTION
This PR fixes a few things that are relevant to one of our projects. Please let me know what you think of this PR. After your go/no-go I'll check out the unit tests, because they aren't working yet (**don't merge this PR**).

* Instead of throwing all configs in `webpack`, I'd prefer to do it one by one sequentially. In projects with multiple functions, memory usage can become a big problem. Therefor I also added `cache: false` to it and don't do anything with the result.
* It runs through the functions and logs it to `serverless` (per function).
* Because the source is webpacked, files can become pretty big. Therefor I added the option to exclude everything, except for the function file itself.
* I also prefer if everything packaged keeps its original path, especially in bigger projects filenames can collide.
* In our case we also use the plugin `CopyWebpackPlugin` which moves over some modules that use c/c++. Therefore `node_modules` is excluded. I know, it's kind of a specific scenario, but I think other people might want to do this too for backends while all other files are included through webpack.